### PR TITLE
DEVOPS Fixing node security groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,6 +306,65 @@ resource "aws_security_group_rule" "demo-node-ingress-cluster" {
   type                     = "ingress"
 }
 
+# Allow 443 from cluster security group to nodes
+resource "aws_security_group_rule" "node-ingress-cluster-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-engress-cluster-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 443
+  type                     = "egress"
+}
+resource "aws_security_group_rule" "node-ingress-coredns-tcp-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 53
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 53
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-ingress-coredns-udp-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 53
+  protocol                 = "udp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 53
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-egress-coredns-tcp-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 53
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 53
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "node-egress-coredns-udp-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 53
+  protocol                 = "udp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 53
+  type                     = "egress"
+}
 
 # EKS Master <--> Worker Security Group
 resource "aws_security_group_rule" "cluster-ingress-node-https" {


### PR DESCRIPTION
Fixing up the node security groups to meet EKS best practices (and to allow nodes to talk to webhooks/cluster api/etc correctly). 

This PR brings the security groups for the nodes inline with https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html with the min requirements set down by AWS for EKS worker nodes.

https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html

Will open 443 between nodes and cluster sec group
Will open 53 for CoreDNS traffic