### PR TITLE
DEVOPS Adding cluster subdomain, external-dns roles

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,8 @@ output "provider_info" {
         }
     ]
     security_group_ids = [aws_security_group.cluster.id, aws_security_group.node.id]
+    external_dns_role_arn = module.iam_assumable_role_external_dns.iam_role_arn
+    external_dns_role_name = module.iam_assumable_role_external_dns.iam_role_name
     fqdn = var.fqdn
   }
 }


### PR DESCRIPTION
Adding in Route53 subdomain creation for cluster
Adding in Route53 NS records for subdomain
Adding in External DNS IAM Role, and policy to work with the cluster subdomain - And IRSA setup
Adding in External DNS policy to the Node Roles (to unblock DNS control until IRSA service account setup in chart/etc)
Adding outputs of the external-dns role arn, and name to the provider info
Fixing up repeating changes from the node security groups
Run formatting